### PR TITLE
[YARN] Automatically create and upload reusable spark jars archive

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -614,8 +614,8 @@ private[spark] class Client(
           YarnCommandBuilderUtils.findJarsDir(sparkConf.getenv("SPARK_HOME")))
         val jars = jarsDir.listFiles().filter { f =>
           f.isFile && f.getName.toLowerCase().endsWith(".jar") && f.canRead
-        }.map(_.getName).sorted
-        s"spark-jars-$SPARK_VERSION-${DigestUtils.md5Hex(jars.mkString)}"
+        }.sortBy(_.getName).map(f => s"${f.getName}|${f.length}")
+        s"spark-jars-$SPARK_VERSION-${DigestUtils.md5Hex(jars.mkString(","))}"
       }
 
       val archiveDirFs = FileSystem.get(archiveDir.toUri, hadoopConf)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -171,6 +171,32 @@ package object config extends Logging {
     .toSequence
     .createOptional
 
+  private[spark] val AUTO_ARCHIVE_ENABLED =
+    ConfigBuilder("spark.yarn.archive.auto.enabled")
+      .doc("When enabled, spark-submit will automatically create and upload a reusable " +
+        s"spark jars archive if it does not exist on HDFS, and rewrite ${SPARK_ARCHIVE.key} " +
+        "to use the archive. To ensure the archive always matches the local spark jars, " +
+        "the archive's filename contains the MD5 of the local spark jars' name.")
+      .version("3.3.4.101")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val AUTO_ARCHIVE_DFS_DIR =
+    ConfigBuilder("spark.yarn.archive.auto.dfsDir")
+      .doc("The HDFS directory used for storing resuable spark jars archive, " +
+        s"must be configured when ${AUTO_ARCHIVE_ENABLED.key} is true. " +
+        "The directory should be manually created with the world-wide rwx permissions.")
+      .version("3.3.4.101")
+      .stringConf
+      .createOptional
+
+  private[spark] val AUTO_ARCHIVE_REPLICATION =
+    ConfigBuilder("spark.yarn.archive.auto.replication")
+      .doc("Replication factor for resuable spark jars archive uploaded to HDFS.")
+      .version("3.3.4.101")
+      .intConf
+      .createOptional
+
   private[spark] val ARCHIVES_TO_DISTRIBUTE = ConfigBuilder("spark.yarn.dist.archives")
     .version("1.0.0")
     .stringConf

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -176,7 +176,7 @@ package object config extends Logging {
       .doc("When enabled, spark-submit will automatically create and upload a reusable " +
         s"spark jars archive if it does not exist on HDFS, and rewrite ${SPARK_ARCHIVE.key} " +
         "to use the archive. To ensure the archive always matches the local spark jars, " +
-        "the archive's filename contains the MD5 of the local spark jars' name.")
+        "the archive's filename contains the MD5 of the local spark jars' name and length.")
       .version("3.3.4.101")
       .booleanConf
       .createWithDefault(false)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Currently, Spark on YARN allows setting `spark.yarn.jars` or `spark.yarn.archive` to speed up the app start process by pre-distributing Spark jars on HDFS, while in practice, things get easy to mess, for example, the user puts new jars under local `$SPARK_HOME/jars` or upgrades the local Spark client but forgets to refresh the HDFS cached archive, or forgets to update `spark.yarn.archive` value in `spark-defaults.conf`, which makes local Spark jars and HDFS-cached Spark jars inconsistent, eventually fail jobs.

When neither `spark.yarn.jars` nor `spark.yarn.archive` is set, spark-submit will fall back to uploading libraries under `$SPARK_HOME/jars`, this is generally cheaper (I tested it on an idle YARN cluster and it took 5-10 seconds), but the archiving (I tested it on a idle YARN cluster, it takes 5~10s), but the archiving process takes up a lot of disk IO and CPU, and the performance of this process will drop sharply as the submission concurrency increases.

This PR brings a new idea to automatically create and upload a reusable Spark jars archive to simplify the Spark on YARN deployment process while still benefiting users with performance improvement.

Core design:
1. Spark jars archive's filename contains the MD5 of the local spark jars' name, like:
   `spark-<VERSION>-<MD5_OF_ALL_JARS_NAME_AND_LENGTH>.zip`
2. If the reusable Spark jars archive is already available at HFDS, rewrite `spark.yarn.archive`, otherwise, create and upload it to HDFS.

To avoid potential concurrency issue, the `spark-submit` process must successfully create the `<archive>.zip.LOCK` file on HDFS before uploading the `<archive>.zip`, then create the `<archive>.zip.SUCCESS` file after uploading is completed, to mark the archive is available for use.

Why ~~`MD5_OF_ALL_JARS_NAME`~~ instead of `MD5_OF_ALL_JARS_FILE`? Because of the IO cost, especially when the Spark client is located on an HDD or a network disk.

Update: the latest version uses both the jar name and length to calculate `MD5_OF_ALL_JARS_NAME_AND_LENGTH`, which should be sufficient to tackle the case that updates the jar but keeps the name unchanged - usually happens when using `SNAPSHOT` versions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Improve performance and simplify the deployment process.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
New feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manual test, the created Spark jars archive looks like

```
$ hadoop fs -ls /spark-archive
Found 2 items
-rw-rw-rw-   3 hadoop supergroup  375264414 2025-07-12 20:26 /spark-archive/spark-jars-3.3.4.101-cf5b132ba321b1f3da1331ba5f415346.zip
-rw-rw-rw-   3 hadoop supergroup          0 2025-07-12 20:26 /spark-archive/spark-jars-3.3.4.101-cf5b132ba321b1f3da1331ba5f415346.zip.SUCEESS
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.